### PR TITLE
Run the scripts using global ruby

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 relative_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ruby ${relative_dir}/post-command.rb
+RBENV_VERSION=`rbenv global` ruby ${relative_dir}/post-command.rb

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 relative_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ruby ${relative_dir}/pre-command.rb
+RBENV_VERSION=`rbenv global` ruby ${relative_dir}/pre-command.rb


### PR DESCRIPTION
Avoids “ruby version xxx not installed” errors due to the plugin running before the repo bootstrapping scripts having been exercuted.