### PR TITLE
Allow disabling the plugin via ENV var

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,19 @@ By default it will cache:
 - rubygems from `vendor/bundle` keyed with ruby version and checksums `Gemfile.lock` checksum
 - npm packages from `node_modules`  node version checksums from  and `yarn.lock`
 
-It will also cache the master branches as fallback for situations where no exact checksun match is found.
+It will also cache the master branches as fallback for situations where no exact checksum match is found.
+
+## Configuration
+
+### Disabling caching
+
+You can use ENV vars to temporarily disable caching.
+
+`BUILDKITE_CACHE_DISABLE=true` disables the entire plugin from running.
+`BUILDKITE_CACHE_DISABLE_RUBY=true` disables caching of `vendor/bundle`.
+`BUILDKITE_CACHE_DISABLE_NODE=true` disables caching of `node_modules`.
+
+### Additional files and directories
 
 If you need to add additional caching of non conventional files you can pass cache keys and paths as a json payload in your `pipeline.yml`.
 

--- a/hooks/post-command.rb
+++ b/hooks/post-command.rb
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+exit if ENV["BUILDKITE_CACHE_DISABLE"] == "true"
+
 require "open3"
 require_relative "../lib/buildkite-cache"
 

--- a/hooks/pre-command.rb
+++ b/hooks/pre-command.rb
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+exit if ENV["BUILDKITE_CACHE_DISABLE"] == "true"
+
 require "open3"
 require_relative "../lib/buildkite-cache"
 

--- a/lib/buildkite-cache.rb
+++ b/lib/buildkite-cache.rb
@@ -8,14 +8,14 @@ module BuildkiteCache
   def self.generate_configuration(json_string = nil)
     keys_and_paths = json_string ? parse_configuration(json_string) : {}
 
-    if File.exist?("Gemfile.lock")
+    if File.exist?("Gemfile.lock") && ENV["BUILDKITE_CACHE_DISABLE_RUBY"] != "true"
       ruby_version = language_version(".ruby-version")
       checksum = checksum("Gemfile.lock")
       key = key("bundle-#{ruby_version}-#{checksum}")
       keys_and_paths[key] = "vendor/bundle"
     end
 
-    if File.exist?("yarn.lock")
+    if File.exist?("yarn.lock") && ENV["BUILDKITE_CACHE_DISABLE_NODE"] != "true"
       node_version = language_version(".node-version", ".nvmrc")
       checksum = checksum("yarn.lock")
       key = key("node_modules-#{node_version}-#{checksum}")


### PR DESCRIPTION
Today we suffered from a corrupt bundle cache which broke our builds. It was easy to fix by deleting the corrupt file and allowing it to be re-built by a subsequent build. However we don't know if we'll get harder to fix issues later down the line when we may need to completely skip cache until we have found a fix.

With this feature merged we can disable the entire plugin or parts of it by setting ENV variables on the Pipeline which is having problems.

### Example builds
Vanilla run: https://buildkite.com/mynewsdesk/mynewsdesk/builds/1031
Plugin disabled: https://buildkite.com/mynewsdesk/mynewsdesk/builds/1032 (aborted after verifying plugin)
Bundle disabled: https://buildkite.com/mynewsdesk/mynewsdesk/builds/1033
Node disabled: https://buildkite.com/mynewsdesk/mynewsdesk/builds/1034
