### PR TITLE
Don’t store cache on failed builds

### DIFF
--- a/hooks/post-command.rb
+++ b/hooks/post-command.rb
@@ -5,6 +5,12 @@ exit if ENV["BUILDKITE_CACHE_DISABLE"] == "true"
 require "open3"
 require_relative "../lib/buildkite-cache"
 
+last_exit_status = ENV.fetch("BUILDKITE_COMMAND_EXIT_STATUS")
+if last_exit_status != "0"
+  puts "Skipping cache plugin since the build appears to have failed (BUILDKITE_COMMAND_EXIT_STATUS was #{last_exit_status})"
+  exit
+end
+
 BUCKET_URL = ENV.fetch("BUILDKITE_CACHE_BUCKET", "s3://buildkite-cache-mnd/")
 configuration = ENV["BUILDKITE_PLUGIN_DEVOPS_BUILDKITE_CACHE_CONFIGURATION"]
 cache_keys_and_paths = BuildkiteCache.generate_configuration(configuration)


### PR DESCRIPTION
Might mitigate generating corrupt package caches in case the build failed due to a package installation error. Will also increase build times in rare scenarios when the build doesn't have a cache available and has failed for other reasons but that trade off seems worth making.

If the build fails:
<img width="1094" alt="Screenshot 2020-01-30 at 13 18 37" src="https://user-images.githubusercontent.com/3461/73449275-14eb2700-4363-11ea-8bdf-70c75f932edc.png">

If the build succeeds (this output also looks like a skip but this skip is from the plugin actually executing):
<img width="1090" alt="Screenshot 2020-01-30 at 13 20 14" src="https://user-images.githubusercontent.com/3461/73449361-43690200-4363-11ea-9c58-c62fa31b4708.png">
